### PR TITLE
fix: global error handler now sets displayed error as ephemeral

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -993,6 +993,7 @@ dependencies = [
  "spectre-wallet-keys",
  "spectre-wrpc-client",
  "tokio",
+ "tracing",
  "workflow-core",
 ]
 

--- a/discord_bot/Cargo.toml
+++ b/discord_bot/Cargo.toml
@@ -13,3 +13,4 @@ spectre-wallet-keys = { git = "https://github.com/spectre-project/rusty-spectre.
 workflow-core = { version = "0.18.0" }
 futures = "0.3.31"
 dotenvy = "0.15.7"
+tracing = "0.1"


### PR DESCRIPTION
This prevents data leak when an unexpected error occurs