### PR TITLE
Make modal confirmation clearer and small resolver fix

### DIFF
--- a/discord_bot/src/commands/destroy.rs
+++ b/discord_bot/src/commands/destroy.rs
@@ -8,7 +8,8 @@ use crate::models::{Context, Error};
 #[derive(Debug, poise::Modal)]
 #[name = "Confirm wallet destruction"]
 struct DestructionModalConfirmation {
-    #[name = "write destroy to confirm"]
+    #[name = "wallet destruction confirmation needed"]
+    #[placeholder = "write \"destroy\" to confirm the wallet destruction"]
     first_input: String,
 }
 
@@ -69,6 +70,13 @@ pub async fn destroy(ctx: Context<'_>) -> Result<(), Error> {
             let embed = create_success_embed("Wallet Destroyed", "");
             return send_reply(ctx, embed, true).await;
         }
+
+        let embed = create_embed(
+            "Wallet Destruction Aborted: Invalid Confirmation Message",
+            "",
+            Colour::DARK_ORANGE,
+        );
+        return send_reply(ctx, embed, true).await;
     }
 
     let embed = create_embed("Wallet Destruction Aborted", "", Colour::DARK_ORANGE);

--- a/discord_bot/src/main.rs
+++ b/discord_bot/src/main.rs
@@ -68,7 +68,13 @@ async fn main() {
 
     // RPC
     let forced_spectre_node: Option<String> = match env::var("FORCE_SPECTRE_NODE_ADDRESS") {
-        Ok(v) => Some(v),
+        Ok(v) => {
+            if v.is_empty() {
+                None
+            } else {
+                Some(v)
+            }
+        }
         Err(_) => None,
     };
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/cfb29101-46d8-4ec1-bc03-a518858f4198)

when confirm keyword isn't used:
![image](https://github.com/user-attachments/assets/e67f32ee-1412-4acc-bb4a-b9ae3ae59dd7)
